### PR TITLE
including wording that clarifies that offensive comments are not ok

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Examples of unacceptable behavior by participants include:
 - The use of sexualized language or imagery and unwelcome sexual attention or advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
-- Verbal or written comments related to gender, sexual orientation, disability, physical appearance, body size, race or religion
+- Verbal or written offensive comments related to gender, sexual orientation, disability, physical appearance, body size, race or religion
 - Publishing others’ private information, such as a physical or electronic address, without explicit permission
 - Other conduct which could reasonably be considered inappropriate in a professional setting
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Examples of unacceptable behavior by participants include:
 - The use of sexualized language or imagery and unwelcome sexual attention or advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
-- Verbal or written offensive comments related to gender, sexual orientation, disability, physical appearance, body size, race or religion
+- Harassment or insensitivity related to gender, sexual orientation, disability, physical appearance, body size, race or religion
 - Publishing others’ private information, such as a physical or electronic address, without explicit permission
 - Other conduct which could reasonably be considered inappropriate in a professional setting
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Examples of unacceptable behavior by participants include:
 - The use of sexualized language or imagery and unwelcome sexual attention or advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
-- Harassment or insensitivity related to gender, sexual orientation, disability, physical appearance, body size, race or religion
+- Harassment or insensitivity related to gender identity or expression, sexual orientation, disability, physical appearance, body size, race or religion
 - Publishing others’ private information, such as a physical or electronic address, without explicit permission
 - Other conduct which could reasonably be considered inappropriate in a professional setting
 


### PR DESCRIPTION
I received some feedback that the current CoC might make it seem like someone organizing a coding group for women would feel like that goal could be against the CoC as it stands.

I revisited the react conf CoC that inspired the change originally and noticed they include a very important word that we don't currently have: offensive.

>Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces

This change adds the word offensive to the clarification on appropriate verbal or written comments.